### PR TITLE
FIX: removed readFileStr and readFileStrSync to use Deno.readTextFile…

### DIFF
--- a/lib/helpers/parseApiFile.ts
+++ b/lib/helpers/parseApiFile.ts
@@ -1,16 +1,13 @@
-import { readFileStr, readFileStrSync } from "https://deno.land/std/fs/mod.ts";
-
-
 import * as path from "https://deno.land/std/path/mod.ts";
-import { parseApiFileContent } from './parseApiFileContent.ts';
+import { parseApiFileContent } from "./parseApiFileContent.ts";
 /**
  * Parses the provided API file for JSDoc comments.
  * @function
  * @param {string} file - File to be parsed
  * @returns {{jsdoc: array, yaml: array}} JSDoc comments and Yaml files
  */
-export function parseApiFile(file : any) {
-  const fileContent = readFileStrSync(file, { encoding: 'utf8' });
+export function parseApiFile(file: any) {
+  const fileContent = Deno.readTextFileSync(file);
   const ext = path.extname(file);
 
   return parseApiFileContent(fileContent, ext);


### PR DESCRIPTION
Deno has removed those imports from std/fs/mod.ts as explained on following
pull request: https://github.com/denoland/deno/pull/6848