### PR TITLE
Fix error with yaml safeload function

### DIFF
--- a/lib/helpers/filterJsDocComments.ts
+++ b/lib/helpers/filterJsDocComments.ts
@@ -16,7 +16,7 @@ export function filterJsDocComments(jsDocComments : any) {
     for (let j = 0; j < jsDocComment.tags.length; j += 1) {
       const tag = jsDocComment.tags[j];
       if (tag.title === 'swagger') {
-        swaggerJsDocComments.push(jsYaml.safeLoad(tag.description));
+        swaggerJsDocComments.push(jsYaml.load(tag.description));
       }
     }
   }

--- a/lib/helpers/parseApiFileContent.ts
+++ b/lib/helpers/parseApiFileContent.ts
@@ -16,7 +16,7 @@ export function parseApiFileContent(fileContent: any, ext: any) {
   const jsDocComments = [];
 
   if (ext === '.yaml' || ext === '.yml') {
-    yaml.push(jsYaml.safeLoad(fileContent));
+    yaml.push(jsYaml.load(fileContent));
   } else {
     const regexResults = fileContent.match(jsDocRegex);
     if (regexResults) {


### PR DESCRIPTION
Great library, thanks for sharing it!  
Unfortunately the library fails at compile time because it is using the old `safeLoad` function which has been removed in `js-yaml 4`. See console error below for more information. This PR replaces all `safeLoad`calls with `load` as suggested by the error text. After that the library works again 😊 

```text
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
    at Object.safeLoad (https://dev.jspm.io/npm:js-yaml@4.1.0/index.dew.js:35:13)
    at filterJsDocComments (https://deno.land/x/deno_swagger_doc@releasev1.0.0/lib/helpers/filterJsDocComments.ts:19:42)
    at updateSpecificationObject (https://deno.land/x/deno_swagger_doc@releasev1.0.0/lib/helpers/updateSpecificationObject.ts:16:5)
    at getSpecificationObject (https://deno.land/x/deno_swagger_doc@releasev1.0.0/lib/helpers/getSpecificationObject.ts:17:5)      
    at swaggerDoc (https://deno.land/x/deno_swagger_doc@releasev1.0.0/lib/index.ts:23:33)
    at file:///C:/Users/myUsername/Downloads/GitHub/Jimmi/backend/src/app.ts:28:21
Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
error: Uncaught Error: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
    throw new Error(err);
          ^
    at swaggerDoc (https://deno.land/x/deno_swagger_doc@releasev1.0.0/lib/index.ts:38:11)
    at file:///C:/Users/myUsername/Downloads/GitHub/Jimmi/backend/src/app.ts:28:21
```